### PR TITLE
feat(ns-system): Repoint object storage from OCI to AWS S3

### DIFF
--- a/ns-system/secrets/ns.yaml
+++ b/ns-system/secrets/ns.yaml
@@ -9,8 +9,8 @@ stringData:
     db-password: ENC[AES256_GCM,data:F8v6fd3B/t7Ol2vqCnu9oGzPdzfV7k2McfEGSUkfUFU=,iv:dAP47no2I2B1udgqgFPuPpijp0sZalZSFz+YYjVOtfo=,tag:r3407eEq3Z5b/G0c6waNgA==,type:str]
     mariadb-password: ENC[AES256_GCM,data:lxLFGFlAb+47XNPZ5Zf48KwH/2ZCYNVfa5lLbSdo7U8=,iv:+6K/aNotHyr+NZ72tqNaQB8MaEteRqv/h71A+0D+oPI=,tag:RXZFSsEYbwXu7doXQFO40g==,type:str]
     mongodb-password: ENC[AES256_GCM,data:ZivsBCBlGo4iNe4aRun+12daOUUYaU6rOKtnZhdZxfs=,iv:IK5NTMCv/dKBezqPclbD05n9y96KTBgqdDwFYbma6hI=,tag:8/7Ls7Jv/j3d1/VnxDLf8A==,type:str]
-    s3-access-key: ENC[AES256_GCM,data:3oz06ElsenZoZh23FhiG1/A8ler4oHp5JZU1Mz6kqX8WjdppMaMiCA==,iv:HO5LjJDhDX/Zw7oO1UMeITyf5QAXC/MPZjgv6uXom84=,tag:ciY+dZgjLniyyPQhSIqCCQ==,type:str]
-    s3-access-secret: ENC[AES256_GCM,data:StAnqbYQaisBgtKCpCLEivWt9iCLFd1SgDeQu2yO7HW7eVErPRipgpkBcm0=,iv:LF/BaDTZJjq+h1sAPr6NI0NMrHkMk43vum1UeF4sq/M=,tag:AiNMPa8Pfe1DqXZ4R+olrQ==,type:str]
+    s3-access-key: ENC[AES256_GCM,data:VZz3ghS00uzmu0bcaCrLNpLo+pk=,iv:jKqN7akxCFFKmrKlqZFiJ5syhstma10yOSGVBNQNfYo=,tag:DwAAZU7ShuW7aCA2Kc/Cjw==,type:str]
+    s3-access-secret: ENC[AES256_GCM,data:CzjiOCq+p+5rEGqt3ktbNcqT7peLGtxGq8bb0afGNIcG4UtKncZY5w==,iv:gvnJYy4n8U6EWSNIzMtfmFP+7dg0ieLj36CUlZqChEU=,tag:q4bOJTuJQt00dev82Bv0Bg==,type:str]
     registry-password: ENC[AES256_GCM,data:/3DW3MbYOu0eK3cxKKNu+IkdyRFwv3L/T7xmtPxEH50=,iv:Whx84RiGxoL61xfm+zfa14mjH2KWlqhhbDEdezByQAg=,tag:VgQKU24+cEhsYGGhyjPFUg==,type:str]
     gitea-token: ENC[AES256_GCM,data:8k621f7Mq1wKGtxbUBy0z4Y+tlNk4vnhh1q2ImarRyGZeCcdywqqQw==,iv:qcmSSOYYsKNtJckwHo6EGEsHWe0iC2kBhMXXlwU0ItU=,tag:wp9zSuXri77hRUMlPRtbmQ==,type:str]
     controller-token: ENC[AES256_GCM,data:Hplic7+0l9rputsD5HgLTmyA/EkMTzhIg+fbdovYZLJDGd0HYqrHVMsm7g==,iv:TRs0WUIYaxmv3Z7q6lVPCu51I+onK3a9biWyVfocK24=,tag:rl+zgg+1lMVP426orqnj9g==,type:str]
@@ -25,7 +25,7 @@ sops:
             NThJK2VRRTcvZVVNT2VmNXd3WlhHdGsKRRxKo+LjVR0BK72Ugth+aHrFA4q7km+q
             FYwSrKM5apWokWktV2xfeA0mRH/R/WYa826CY4GYihxAnuAEuq1JzA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-07-26T02:31:00Z"
-    mac: ENC[AES256_GCM,data:rcQT8izB6KZEgQCSSPPbmhsRySk1fpQpQXxCtoKaxEDXMjEYSArw2qc0zCtVqXgb605bB0RbNlctIVouznsponrYJY76FlQgCnxY+5/wDk8NZi+XT/GB5gd550ksL/M7mb8OH1/MRBI5CeQeLPvjwcPIfPBVSVl9GkPmAsCRyso=,iv:YelfTMhyNE/KLO1VlDzWSrKgD+iXoOi705zabVw5iXA=,tag:NB/QHkROmSA+twJ5sMU3Ew==,type:str]
+    lastmodified: "2026-07-06T13:05:33Z"
+    mac: ENC[AES256_GCM,data:2pwcMaJm23Qpr8qpNTg9MS4gOnnrS8jtssmQJyI33eBcX4ZuX3dsWr30zLgiIvKi2zYf/DR/zOuqxIGYnZiKQunQKUQY8BzFLbC/RzMK4Rt+BHs0hJ6fV9Y5G/r3earQ9PkTGkq4CM4ZwaAzVf7GEtYjBPH9MCnF4GgJlIdOJt8=,iv:PewBHtPzKSZnJhSvpQoXOxwZ2OxozYSWtd4GO8bOANg=,tag:dJ5fvgZsKFFy3z2v7L3nqA==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.10.2

--- a/ns-system/values.yaml
+++ b/ns-system/values.yaml
@@ -9,11 +9,12 @@ common:
   storage:
     type: s3
     s3:
-      bucket: neoshowcase
+      bucket: toki317-neoshowcase
       # accessKey: <defined by secret>
       # accessSecret: <defined by secret>
-      region: ap-osaka-1
-      endpoint: https://axekqehyne6j.compat.objectstorage.ap-osaka-1.oraclecloud.com
+      region: ap-northeast-1
+      # NeoShowcase sets BaseEndpoint unconditionally, so keep an explicit AWS regional endpoint.
+      endpoint: https://s3.ap-northeast-1.amazonaws.com
 
   image:
     registry:


### PR DESCRIPTION
**Draft / do-not-merge** until the prerequisites below are done. Merging this repoints NeoShowcase at AWS; ArgoCD syncs `main`, so a merge *is* the cutover.

## What

`ns-system/values.yaml` storage → `toki317-neoshowcase` bucket, `ap-northeast-1`, AWS regional endpoint. This is also the fix for the current `501 NotImplemented: AWS chunked encoding not supported` build-save failures — AWS S3 supports `aws-chunked` natively, OCI does not.

Endpoint stays explicit (not empty) because NeoShowcase's `NewS3Storage` sets `BaseEndpoint` unconditionally. Path-style stays hard-coded in NeoShowcase and still works on AWS.

## Gate — do all of these before marking ready & merging

- [ ] **Bucket + IAM live**: merge `motoki317/toki317.dev#11` (creates `toki317-neoshowcase` + the `s3-neoshowcase` user)
- [ ] **Access key created**: `aws iam create-access-key --user-name s3-neoshowcase --profile toki317-admin` (secret shown once)
- [ ] **Data copied**: `rclone sync oci:neoshowcase aws:toki317-neoshowcase` (one-shot — writes already 501-fail on OCI, so nothing new lands there)
- [ ] **Secret swapped in THIS branch**: `sops ns-system/secrets/ns.yaml` → set `s3-access-key` / `s3-access-secret` to the new AWS creds, commit to this branch. Values + creds must land in the **same merge**, or ArgoCD serves AWS-bucket config with OCI creds.

## After merge

- ArgoCD syncs → `ns-controller` / `ns-gateway` / builders redeploy
- Trigger a build → artifact + build-log save succeed; no `501` / `aws-chunked` in `ns-builder` logs

## Not included (intentional)

- The `AWS_REQUEST_CHECKSUM_CALCULATION` patch in `kustomization.yaml` is now a no-op on AWS but harmless; optional cleanup in a later, separate commit.

Full runbook + rollback: `.local/plans/neoshowcase.md`.