### PR TITLE
feat(harbor): Repoint registry storage from OCI to AWS S3

### DIFF
--- a/harbor/secrets/storage.yaml
+++ b/harbor/secrets/storage.yaml
@@ -3,13 +3,9 @@ kind: Secret
 metadata:
     name: storage
 stringData:
-    REGISTRY_STORAGE_S3_ACCESSKEY: ENC[AES256_GCM,data:k3o1hOFNowv5lWv/Z6v4MmH7CldCQoEOqHWcTMxw00XdbLUUi/Gnpg==,iv:XkTJJyTQC1MO8qisdqa5yR9bxSayh9Hve5KkIGCKtco=,tag:R4zpr+KM5q3fftlYWrdaPA==,type:str]
-    REGISTRY_STORAGE_S3_SECRETKEY: ENC[AES256_GCM,data:1OlOSMGAZj/6i6oqLOgJAqpU8qeiXaZEMg7dHBGL1ZUX/6kVMLgaN9dZM6Y=,iv:L5+zWd+V2snLUAOqsEM9SCpn84Zwod/kZ8wPOmAJyrk=,tag:IVs0JgoRTOp5FmXCUoW9ug==,type:str]
+    REGISTRY_STORAGE_S3_ACCESSKEY: ENC[AES256_GCM,data:1LFQKMuSz5Fs0p/fUbnsmI+zYmI=,iv:IVd8Gd0KvbtyinNBx7c6Tv/7lWMv08VSaBQ2K6l09qQ=,tag:hK2bcmYNENjRKjXJyUSQpg==,type:str]
+    REGISTRY_STORAGE_S3_SECRETKEY: ENC[AES256_GCM,data:Enp1P9UiU8ajkYpR2qvg/qW+e3HXOCke74p6mL1kHi/0pxPwvnj5ZA==,iv:7w1XyzvCaAAWu3BWRStuYJFlfZfRy0Mw2kaPay/1zdQ=,tag:D8Dc9E4O1fKtfjmt7si2bQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1g2rwkffct3veu3zl5a09cny4qgjw5he9drdxjwxqclzq6fa0ldtql4kxvd
           enc: |
@@ -20,8 +16,7 @@ sops:
             NThJK2VRRTcvZVVNT2VmNXd3WlhHdGsKRRxKo+LjVR0BK72Ugth+aHrFA4q7km+q
             FYwSrKM5apWokWktV2xfeA0mRH/R/WYa826CY4GYihxAnuAEuq1JzA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-10-12T08:57:24Z"
-    mac: ENC[AES256_GCM,data:vSbekoZoec2zOP6JWxAcccJdn2E7pKs9uvXNZbfFr71IfFIo3SDIhKiRwK9lxYm5ukKlXdPqN2VRiaaROsX7ad3n/LwvDd3ijIY57M1lI+Q1+g6xBXkGUz35N/jHCVyMeW/Q5RXOslOm73Iev6w9kCShXcS+rn8FDl596CzQHn8=,iv:seBYrgRq7/V3YowwAWr1/YlLl/v/3IuynfQXeuLk2bI=,tag:hLIlzvuAyOetH6GO/QkfNQ==,type:str]
-    pgp: []
+    lastmodified: "2026-07-06T13:49:51Z"
+    mac: ENC[AES256_GCM,data:rZDF22bJWI67H1LKFczm7abhCW47u2gVjD4UA6I0V2J3gg8PX4uH85H5LjsyXKYyRALOG3RlEprzePwknhgsclhEHs1tz4bFxdIYlWdKMdkQl27ZijThmgxpHiVw1uRIuucddW3dASOM7wGkv1ezZn/wrMVhLrKN1/FIacqBSDA=,iv:K08Sk+IzRj4/dgy5C0xR6vckrRRPvCz0+V6Rth8dXZA=,tag:P2Cj/IuOsHENoVXyi9T+2w==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.7.3

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -31,9 +31,8 @@ persistence:
       # Set an existing secret for S3 accesskey and secretkey
       # keys in the secret should be REGISTRY_STORAGE_S3_ACCESSKEY and REGISTRY_STORAGE_S3_SECRETKEY for registry
       existingSecret: "storage"
-      region: ap-osaka-1
-      bucket: harbor
-      regionendpoint: https://axekqehyne6j.compat.objectstorage.ap-osaka-1.oraclecloud.com
+      region: ap-northeast-1
+      bucket: toki317-harbor
 
 imagePullPolicy: Always
 


### PR DESCRIPTION
Migrates Harbor registry storage OCI→AWS (2nd app after NeoShowcase). Data already copied to `toki317-harbor` (1971 objects, verified 0 diffs).

- values.yaml: bucket `harbor`→`toki317-harbor`, region `ap-osaka-1`→`ap-northeast-1`, drop OCI `regionendpoint` (AWS default endpoint).
- storage secret: AWS creds for IAM user `s3-harbor` (validated).

**Post-merge:** `kubectl rollout restart deploy/harbor-registry harbor-jobservice` (registry loads the secret at startup). Storage secret is fixed-name + no hooks → no ns-style sync deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)