### PR TITLE
feat(traq): Repoint file storage from OCI to AWS S3

### DIFF
--- a/traq/config/config.yml
+++ b/traq/config/config.yml
@@ -25,9 +25,9 @@ es:
 storage:
   type: s3
   s3:
-    bucket: traq
-    region: ap-osaka-1
-    endpoint: https://axekqehyne6j.compat.objectstorage.ap-osaka-1.oraclecloud.com
+    bucket: toki317-traq
+    region: ap-northeast-1
+    endpoint: https://s3.ap-northeast-1.amazonaws.com
     # accessKey: <env secret>
     # secretKey: <env secret>
     forcePathStyle: true

--- a/traq/secrets/traq.yaml
+++ b/traq/secrets/traq.yaml
@@ -7,8 +7,8 @@ metadata:
 stringData:
     mariadb-password: ENC[AES256_GCM,data:1i3W43ZnjzrkZsFpRMs3t9RqETYE+w==,iv:RWc9l4Ucadq2ZKmn3rbBvELKv3lHfWi8i4MrCtAz/6I=,tag:dJW1B3fdnKAF89+Y5/G6RA==,type:str]
     skyway-secret: ENC[AES256_GCM,data:Hhp2Qi8XPgnObdGQb76d+hGbmD24Jj8T3naRtkYrVCY=,iv:zKBEeEmdISTJ98tRCdLsuGDVy3CmnDE/nTqebOnGyPI=,tag:vzcIq3mKByE0ZPxuMpDU5g==,type:str]
-    s3-access-key: ENC[AES256_GCM,data:ONOUPvua666HT+j17lw4rQSLTIF+UhVSq1Nwwz+YA9pbgzJvttJZWA==,iv:KbsSFFbus6YiHTHcuU9VAcpxZGsCabpiqFFgXw79eto=,tag:3HW689BD0hOlN7foioz5jw==,type:str]
-    s3-secret-key: ENC[AES256_GCM,data:ZHg+tJQy12oCHdwZeMAA+DfyJVsU5gJlooh7x+kC+qllpsDgAjxe0hay4lw=,iv:vmSv1J2jUcy+IazPJPqd+SdIiy0z+ZKdnWWXTBXEWSo=,tag:Yg2iU6XEYdaQWXOOJOc6gw==,type:str]
+    s3-access-key: ENC[AES256_GCM,data:a9pOLVw27vWAjAefFcqCx2w1YTc=,iv:9JbdAhJ0ifT6I2XZ9nfYlsoPVMgHOpH2GCQXy8YRyXA=,tag:UGk3QyFeCoU+Tz/czOZoZA==,type:str]
+    s3-secret-key: ENC[AES256_GCM,data:/rYm1HdMqhwjeq1HfMcZnPmNBUo25uSRS562E0EyjPd7fVuhTlfJrA==,iv:9MIujtofM7gQz5cNfO6GKURpt4W8BSDULp9acdEf+rg=,tag:TI1aLZCGIQq4eZ9auCX+lg==,type:str]
     es-password: ENC[AES256_GCM,data:TPaQ13MYQYAtvRmxeE2I6kprOPkI3o6lr3m3npeHsS8=,iv:FwEjRWtMSziWwjNvC4YNqyZF/lybNE02rzjiad8Wpss=,tag:dECcpyxAm5/GVV0u33C1xA==,type:str]
 sops:
     age:
@@ -21,7 +21,7 @@ sops:
             S0x2TS9yTU56N0NmTlYydVN6L012K00KzODLQGA316ejNJfIFvq39SpJKuIJhSUy
             tSHO5BfQ/dr/vlCyXYegPY6earrWOBXHjIQdWrv2ZeDBaDKFEPrtFQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-14T11:44:55Z"
-    mac: ENC[AES256_GCM,data:UaJdgqX/2/+b8CjCo3ANFEAi5D5Ph5vtA1Eq9vpQkq/bCJHHOhVKb45ez3+qY6BfH/1twqSC9e5aw7hUV95UpUvasvyzCf35fU7sM+CvEyif2GLyJN2hTVPGq6QDLiQs0TFDiwlk4MhykVqBjoTn2jTBkTZxJMXVa+wk3+uXNhI=,iv:recBwCSood0ub7Tg7OQfiD14HgiMEEgKkaPITTAkXTs=,tag:3KIvzCZ1E+AmPzODOV95Sg==,type:str]
+    lastmodified: "2026-07-06T14:11:57Z"
+    mac: ENC[AES256_GCM,data:jBWxik/Vkyobl0Li+85441hNVUhTrG4IdXf8CksJgoQxx0/nKH98b3S5zsLhahhgwvg25v4meSX03OfzmFBY//4Qu/F5BijwDfZ5VyK2e7IHUy6oUJOHtupsqs/oXfNL0ERYL0U5ZqIjN0rt1i+cMWtszUwDcsR5WxJNvrEnP90=,iv:6zyfrENUTaxc0hMfxpv73mNiWUBKkG5un4PCXNR0uQ4=,tag:wuyXbTkxRW+S6KxSgnWvPw==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.10.2


### PR DESCRIPTION
Migrates traQ file storage (user icons/attachments) OCI→AWS (3rd app). Data copied to `toki317-traq` (2010 objects, verified 0 diffs).

- config.yml: bucket `traq`→`toki317-traq`, region→`ap-northeast-1`, AWS endpoint; forcePathStyle kept.
- traq secret: AWS creds for IAM user `s3-traq` (validated).

Secret+config are hash-suffixed (no hooks) → ArgoCD rolls the traq StatefulSet automatically; brief (~30s) traQ restart. Reconciling copy after cutover for the transition window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)