### PR TITLE
feat(monitor/s3-exporter): Repoint bucket metrics from OCI to AWS S3

### DIFF
--- a/monitor/s3-exporter/secrets/s3-exporter.yaml
+++ b/monitor/s3-exporter/secrets/s3-exporter.yaml
@@ -5,15 +5,11 @@ metadata:
     annotations:
         kustomize.config.k8s.io/needs-hash: "true"
 stringData:
-    access-key: ENC[AES256_GCM,data:H4p1L0RaAKtMXeqsPb3ecY6iOwHMIuq8N1OiL4yhu7e/rfvwfMTg1g==,iv:04UjDSnomOVVfcF8Kfg82o6bwYgE+e3tsLfszHRLsgQ=,tag:+F0FUQQ+G/Lefx0dup6FsA==,type:str]
-    secret-key: ENC[AES256_GCM,data:r36bZte7/Evyi8DS3bxwYsFh0T/QTgYmd0zCcahkE9onfB9XFscUOvnLK4s=,iv:fb4I53FdB8JBLXAwgMAf8vf6dFRNifeVV2KSkgNTVAk=,tag:sTeWAcTLnjvK0ExmIuLE5g==,type:str]
-    endpoint: ENC[AES256_GCM,data:xJWqmem+0k2pPGVdhXEnB1rfXmQJXEa8wfkMK3Vz0IbsJDxhy8p0C1I5Qdd5qvm/2RSWFMw3Vo0JmzWWyzVUujb/r4M=,iv:RVtcW8I1y5iHxaYAzEUy+nrX3MybujuXAzJJWjU18tE=,tag:qsdm5Tr9oTS92GsSZGBvPA==,type:str]
-    region: ENC[AES256_GCM,data:znwVCyNWq7HREA==,iv:XZLgv2/VY25GdnEJqNdI8w1sKrem/z6bcXxw40x9UPI=,tag:KHmAk27SjMHrPlQnhaagPQ==,type:str]
+    access-key: ENC[AES256_GCM,data:4ewF6jBOC0hR8o+63foWAkvwt2Q=,iv:hG5J7ZKZZgzwTyW4Iqtiy/WuuWG2hU67jNaW9l8e1dQ=,tag:el/MBEJJJup7OkVp3HDKlA==,type:str]
+    secret-key: ENC[AES256_GCM,data:nuMV4blJN/bXw7NpxHUSjPRzBvh0GO6QSuLK/SP+FQCvFv80D2Mxjw==,iv:Gy1yhoQ/TynDhwPR8hILDtI9MpqKeD6TYJtDA9U0QNc=,tag:W+umqY7gc/5ummL+VdSlFg==,type:str]
+    endpoint: ENC[AES256_GCM,data:iHqXcCftWsD4NtxJPXS94g+QxW2QabO4izCt545c/vkyYfCTOjcg,iv:PEiOXVDg02jDMWUj8LnSsUBjOpCuwGkv9l3XPoJlfB8=,tag:uHFOgKThynLgTNKXv5qQHA==,type:str]
+    region: ENC[AES256_GCM,data:Gbo840yp2FrKoqSCCtA=,iv:u4vOfi0KGbb0zvJ9O2RvZJLvkRSPCg55zyNsRcmEMG8=,tag:rpDXXxkDf9iGLuGptXIpmg==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1g2rwkffct3veu3zl5a09cny4qgjw5he9drdxjwxqclzq6fa0ldtql4kxvd
           enc: |
@@ -24,8 +20,7 @@ sops:
             a2pTbkovVGtvcWtieHoxa21ETk0wVlUKamM3G60wcWXQVEJxMfrWOja8uxqWVlKE
             eOlHFP3J3LCnHbzsUJrrxapvgz1GPlxEs7vwocWsmb+6SBDl7XC2Dw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-10-16T03:08:32Z"
-    mac: ENC[AES256_GCM,data:yDtvmX21BY7NRXA1ys9Bx2chMvFBtDZlDV/6q1eDnD7TjRS9qDju8RV0xM327jiMvVa7t7FtSuksQjPAFtz9BM844z5AxkKciczOQxfvKRjsgsFlk/P7znl8Vo2RQ7uD91YLb08XpYAyffaAYBE9j9Su/bFOJ5RjGXlJJxfDcZA=,iv://OuxTdQVQICNTlWhIyoSBh//ZhavCT/y/txmgLRm3w=,tag:ud/gRfvsAeMWtuqcTjhZ3g==,type:str]
-    pgp: []
+    lastmodified: "2026-07-06T14:24:56Z"
+    mac: ENC[AES256_GCM,data:nw6bPCpeeW8YYqpvK6Vb2bdlZV1HOZEXfm7ArqqmyCgOtu+hMnNsM4NK2NgcG/pf5YPdxYEzwRaMVRvQNILODkwlQOy0IQG2f+CF6cOB8IxvZvXJa9wBGYw0Hj1HGpUyKAh+WfnepImDRQ2w+0ruSE7HtFDheeLaqrd4wVt8V6k=,iv:OGWqHtH2Z4DefbUc01BhF4waiKty5z5SOm/xlcnkUM0=,tag:Bb74n6X/WMmByxvdmEnHXQ==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.7.3


### PR DESCRIPTION
Final app in the OCI→AWS migration. Repoints the Prometheus s3_exporter to AWS (endpoint + region ap-northeast-1) using the read-only `s3-exporter` IAM user (ListAllMyBuckets + ListBucket, no object access — validated: discovery lists all 4 toki317-* buckets, GetObject denied).

No data copy (metrics only). Hash-suffixed secret → ArgoCD auto-rolls the exporter Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)